### PR TITLE
Count locked jobs as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ SqlStore.prototype.connect = function (cb) {
       throw new Error("Unhandled dialect: " + dialect);
     }
     self.adapter.knex.raw(sql).then(function () {
-      self.adapter.knex(self.tableName).count('*').where('lock', '').then(function (rows) {
+      self.adapter.knex(self.tableName).count('*').then(function (rows) {
         var row = rows[0];
         cb(null, row ? row['count'] || row['count(*)'] : 0);
       });


### PR DESCRIPTION
If the app is killed during runtime, last active job is stored in DB with lock.

After the app starts again, it process all the remaining jobs (even the one with the lock) except the last one - because the SqlStore connect does not report "locked" jobs in DB.

Expected behaviour: connect method counts all the jobs in DB - even the locked ones -> better-queue will not forget any jobs in the queue in the end.