### PR TITLE
Add support for ssl connections in PostgresAdapter

### DIFF
--- a/postgres.js
+++ b/postgres.js
@@ -13,6 +13,11 @@ PostgresAdapter.prototype.connect = function (cb) {
       user: this.username || 'postgres',
       password: this.password || '',
     };
+  
+  if (this.ssl) {
+    extend(connection, { ssl: this.ssl })
+  }
+
   this.knex = require('knex')({
     client: 'pg',
     connection: connection,


### PR DESCRIPTION
In some production environments is required to enable `ssl` to the Postgres connection. This PR allows to add the `ssl` config object to the Knex connection settings as is described here (https://github.com/knex/knex/issues/2741)