### PR TITLE
added option to set sqlite request timeout.

### DIFF
--- a/sqlite.js
+++ b/sqlite.js
@@ -20,7 +20,7 @@ SqliteAdapter.prototype.connect = function (cb) {
     pool: {
       min: 1,
       max: 1,
-      requestTimeout: 200,
+      requestTimeout: this.requestTimeout || 200,
     },
     refreshIdle: false,
     acquireConnectionTimeout: this.acquireConnectionTimeout || 200,


### PR DESCRIPTION
On slow systems, the default `requestTimeout` of 200 is too short. This allows for the `requestTimeout` to be configurable.